### PR TITLE
remove space from page string join

### DIFF
--- a/pwmt/page.py
+++ b/pwmt/page.py
@@ -21,7 +21,7 @@ class Page:
 
                     head += line
 
-                self.body = " ".join(content[idx:]).strip()
+                self.body = "".join(content[idx:]).strip()
                 self.head = head
 
             self.meta = yaml.safe_load(self.head) or {}


### PR DESCRIPTION
resolves #4 .

Join operation had a space separator, so the markdown wouldn't appear as in the files.